### PR TITLE
Updates go.mod to match fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/adityatelange/hugo-PaperMod
+module github.com/reorx/hugo-PaperModX
 
 go 1.12


### PR DESCRIPTION
Adding go module was broken:

> module declares its path as: github.com/adityatelange/hugo-PaperMod
	        but was required as: github.com/reorx/hugo-PaperModX

This should fix it.